### PR TITLE
Convert old spammers to new blocking mechanism

### DIFF
--- a/2022/0201.md
+++ b/2022/0201.md
@@ -1,0 +1,26 @@
+# 2022/02/01 封鎖過去「廣告灌水者」
+
+過去公告過的廣告灌水者如下：
+
+| 廣告灌水者 | 過去公告 |
+| - | - |
+| [yegogo](https://cofacts.github.io/community-builder/#/editorworks?type=0&day=180&showAll=1&userId=vA43ZHEBrhVJn3LNSSe8) | https://github.com/cofacts/takedowns/blob/master/2020/1125-yegogo.md |
+| [lylefeierman403](https://cofacts.github.io/community-builder/#/editorworks?type=0&day=180&showAll=1&userId=NqhJ9ncB9w1KR1Ik3Pz1) | https://github.com/cofacts/takedowns/blob/master/2021/0303-ads.md |
+| [陽曉曉](https://cofacts.github.io/community-builder/#/editorworks?type=0&day=180&showAll=1&userId=Jqk6DHkB9w1KR1IkC3kX) | https://github.com/cofacts/takedowns/blob/master/2021/0426-ads.md |
+| [SUOLEMENGUANLECHUANG](https://cofacts.github.io/community-builder/#/editorworks?type=0&day=180&showAll=1&userId=H0NZM3sBgBgcuemXLgJ7) | https://github.com/cofacts/takedowns/blob/master/2021/0811-ads.md |
+| [asd A](https://cofacts.github.io/community-builder/#/editorworks?type=0&day=180&showAll=1&userId=YUOoNHsBgBgcuemXIQMD) | https://github.com/cofacts/takedowns/blob/master/2021/0811-ads.md |
+| [謝汗馬](https://cofacts.github.io/community-builder/#/editorworks?type=0&day=180&showAll=1&userId=M_TJ13sBqH8xU4AwssJ3) | https://github.com/cofacts/takedowns/blob/master/2021/0915-ads.md |
+| [陳伊楠](https://cofacts.github.io/community-builder/#/editorworks?type=0&day=180&showAll=1&userId=eMK5MXwBucwAqrba5dVh) | https://github.com/cofacts/takedowns/blob/master/2021/0929-ads.md |
+| [呂生](https://cofacts.github.io/community-builder/#/editorworks?type=0&day=180&showAll=1&userId=TMKEZHwBucwAqrba8PQi) | https://github.com/cofacts/takedowns/blob/master/2021/1010-ads.md |
+| [林芭比](https://cofacts.github.io/community-builder/#/editorworks?type=0&day=180&showAll=1&userId=TcNKA30BucwAqrbacnEW) | https://github.com/cofacts/takedowns/blob/master/2021/1111-ads.md |
+| [jhon wanone](https://cofacts.github.io/community-builder/#/editorworks?type=0&day=180&showAll=1&userId=d8NuBX0BucwAqrbaW3Np) | https://github.com/cofacts/takedowns/blob/master/2021/1111-ads.md |
+| [全台本土妹茶訊](https://cofacts.github.io/community-builder/#/editorworks?type=0&day=180&showAll=1&userId=KqRzYH0BnX5-aOa4JWIT) | https://github.com/cofacts/takedowns/blob/master/2021/1127-ads.md |
+| [阮明明](https://cofacts.github.io/community-builder/#/editorworks?type=0&day=180&showAll=1&userId=QaSsx30BnX5-aOa4Iod7) | https://github.com/cofacts/takedowns/blob/master/2021/1229-spam.md |
+
+這些使用者之行為亦符合 [2021/10/18 公告](https://www.facebook.com/groups/cofacts/posts/3111789079052900/)的新廣告使用者處理方式，故循[前例](https://github.com/cofacts/takedowns/blob/master/2021/1125-2nd-spam.md)對以上使用者進行下列處置：
+
+1. 於資料庫中註記此使用者為被封鎖的使用者，檢附此公告的連結。
+2. 隱藏此使用者的所有「回應」、「補充」、與「評價」。
+3. 透過被封鎖的使用者登入過的瀏覽器，仍可在網站上看到自己的回應、補充與評價。
+
+爾後過去公告中提及之「[廣告灌水者貼文](https://docs.google.com/spreadsheets/d/1BBObfTO7bLWERQ3nq3S1iBs3xt2o2TgOxikXqixOdYI/edit#gid=1972732064)」試算表將不再更新，可點擊上表的使用者名稱看該使用者之貼文內容。


### PR DESCRIPTION
This announcement will convert old spammers to new [blocking mechanism](https://www.facebook.com/groups/cofacts/posts/3111789079052900/), so that new posts of these spammers will be directly hidden as soon as they are posted.

After this we no longer need to [monitor](https://docs.google.com/spreadsheets/d/1BBObfTO7bLWERQ3nq3S1iBs3xt2o2TgOxikXqixOdYI/edit#gid=0) these spammers.