### PR TITLE
fix: query time range issue due to GitHub schedule highload

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -15,8 +15,8 @@ COFACTS_URL=https://dev.cofacts.tw
 # Query article replies from Cofacts API
 COFACTS_API_URL=https://dev-api.cofacts.tw/graphql
 
-# Specifies the time range to query replies from `REVIEW_REPLY_BEFORE`
-REVIEW_REPLY_BEFORE={ "seconds":0, "minutes":0, "hours":23, "days":46 }
+# Specifies the `LAST_SCANNED_AT` date to query replies from
+LAST_SCANNED_AT=2024-12-20T06:26:30.026Z
 
 # Optional: use langfuse for tracing the llm response
 LANGFUSE_SECRET_KEY=

--- a/.github/workflows/takedown.yml
+++ b/.github/workflows/takedown.yml
@@ -25,7 +25,7 @@ jobs:
           GITHUBAPP_INSTALLATION_ID: ${{ secrets.GITHUBAPP_INSTALLATION_ID }}
           COFACTS_URL: ${{ vars.COFACTS_URL }}
           COFACTS_API_URL: ${{ vars.COFACTS_API_URL }}
-          REVIEW_REPLY_BEFORE: ${{ vars.REVIEW_REPLY_BEFORE }}
+          LAST_SCANNED_AT: ${{ vars.LAST_SCANNED_AT }}
           LANGFUSE_BASEURL: ${{ vars.LANGFUSE_BASEURL }}
           LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
           LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}

--- a/.github/workflows/takedown.yml
+++ b/.github/workflows/takedown.yml
@@ -10,6 +10,14 @@ jobs:
     environment: ${{ github.ref == 'refs/heads/master' && 'production' || 'staging' }}
     runs-on: ubuntu-latest
     steps:
+      - name: Setup environment variable
+        run: |
+          if [ "${{ github.ref }}" == "refs/heads/master" ]; then
+            echo "CURRENT_ENV=production" >> $GITHUB_ENV
+          else
+            echo "CURRENT_ENV=staging" >> $GITHUB_ENV
+          fi
+
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
@@ -29,5 +37,5 @@ jobs:
           LANGFUSE_BASEURL: ${{ vars.LANGFUSE_BASEURL }}
           LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
           LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
-          ENV: ${{ github.environment }}
+          ENV: ${{ env.CURRENT_ENV }}
         run: npm run takedown

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@octokit/auth-app": "^7.1.2",
         "@octokit/rest": "^21.0.2",
         "babel-plugin-module-resolver": "^4.0.0",
-        "date-fns": "^4.1.0",
         "dotenv": "^16.4.5",
         "eslint": "^8.0.0",
         "eslint-config-prettier": "^8.0.0",
@@ -2512,15 +2511,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/date-fns": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "@octokit/auth-app": "^7.1.2",
     "@octokit/rest": "^21.0.2",
     "babel-plugin-module-resolver": "^4.0.0",
-    "date-fns": "^4.1.0",
     "dotenv": "^16.4.5",
     "eslint": "^8.0.0",
     "eslint-config-prettier": "^8.0.0",

--- a/src/githubPR.js
+++ b/src/githubPR.js
@@ -202,3 +202,15 @@ export async function getAllPRs() {
     throw error;
   }
 }
+
+// https://octokit.github.io/rest.js/v21/#actions-update-environment-variable
+export async function updateEnvironmentVariable(env, varName, value) {
+  const octokit = await getGithubApp();
+  await octokit.rest.actions.updateEnvironmentVariable({
+    owner,
+    repo,
+    environment_name: env,
+    name: varName,
+    value,
+  });
+}

--- a/src/githubPR.js
+++ b/src/githubPR.js
@@ -41,7 +41,7 @@ export async function createPullRequest({
   id,
   userId,
   userName,
-  spam_content,
+  spamContent,
   createdAt,
   userReplyHistory,
 }) {
@@ -59,7 +59,7 @@ export async function createPullRequest({
     const spammerNameWithLinkToTheirWork = `[${userName}](https://cofacts.github.io/community-builder/#/editorworks?showAll=1&day=365&userId=${userId})`;
     const trimmedContent = `[查核回應](${
       process.env.COFACTS_URL
-    }/reply/${id})<br>\`${ellipsis(spam_content, 300)}\``;
+    }/reply/${id})<br>\`${ellipsis(spamContent, 300)}\``;
     const contentDate = Intl.DateTimeFormat('zh-TW', {
       year: 'numeric',
       month: 'numeric',

--- a/src/takedown.js
+++ b/src/takedown.js
@@ -67,7 +67,7 @@ async function processSpamRepliesFromDate(date) {
           id,
           userId: user.id,
           userName: user.name,
-          spam_content: text,
+          spamContent: text,
           createdAt,
           userReplyHistory,
         });

--- a/src/takedown.js
+++ b/src/takedown.js
@@ -1,7 +1,10 @@
 import { getRepliesInBatch, getUserReplies } from './util/graphql.js';
 import { getSpamList } from './getSpamList.js';
-import { getAllPRs, createPullRequest } from './githubPR.js';
-import subTime from 'date-fns/sub';
+import {
+  getAllPRs,
+  createPullRequest,
+  updateEnvironmentVariable,
+} from './githubPR.js';
 
 const knownUsers = new Set();
 const seenTexts = new Set();
@@ -76,16 +79,17 @@ async function processSpamRepliesFromDate(date) {
   }
 }
 
-function getDateBefore(timeOffset) {
-  const date = subTime(new Date(), timeOffset);
-  return date;
-}
-
 async function main() {
   await initKnownUsers();
-  // { "seconds":4, "minutes":3, "hours":2, "days":1 }
-  const timeOffset = JSON.parse(process.env.REVIEW_REPLY_BEFORE) || {};
-  await processSpamRepliesFromDate(getDateBefore(timeOffset));
+
+  const lastScannedAt = new Date(process.env.LAST_SCANNED_AT);
+  // write last scanned time to github environment variable
+  await updateEnvironmentVariable(
+    process.env.ENV,
+    'LAST_SCANNED_AT',
+    new Date().toISOString()
+  );
+  await processSpamRepliesFromDate(lastScannedAt);
 }
 
 main().catch((err) => {


### PR DESCRIPTION
We cannot repeatedly query replies with the same time range since the schedule does not guarantee running every ten minutes.

So I replaced `REVIEW_REPLY_BEFORE` with `LAST_SCANNED_AT`, and store the last scanned time in GitHub environment variables.

Other changes
 - fix cannot get github action environment
   -  <img width="384" alt="截圖 2024-12-23 下午5 44 28" src="https://github.com/user-attachments/assets/d383f293-6ddc-4590-b587-dc855215f4aa" />
 - rename spam_content to spamContent

Test result in [#364](https://github.com/cofacts/takedowns/actions/runs/12463889515/job/34787031944).