### PR TITLE
Fix ReferenceError: moderation is not defined

### DIFF
--- a/src/githubPR.js
+++ b/src/githubPR.js
@@ -121,7 +121,7 @@ ${tableRows.join('\n')}
     const prDescription = `This PR was created by Takedown Bot
 
 Takedown command:
-- API: `/moderation/blockUser`
+- API: \`/moderation/blockUser\`
 - Body:
   \`\`\`json
     {"userId":"${userId}", "blockedReason":"https://github.com/cofacts/takedowns/blob/master/${fileName}"}


### PR DESCRIPTION
修復自動化 takedown 腳本中的錯誤。

![圖片](https://github.com/user-attachments/assets/5e47a300-052a-4a1c-a331-f80697911c34)

問題：
PR 描述中的路徑字串 `/moderation/blockUser` 使用普通引號包裹，導致 JavaScript 嘗試將 `moderation` 解析為變數，但它未被定義，因此引發 `ReferenceError: moderation is not defined` 錯誤。

修復方法：
在字串中使用轉義的反引號 `\` 來表示路徑，讓它被視為純文字而非程式碼。