### PR TITLE
fix: remove try-catch block in processSpamRepliesFromDate to properly throw errors

### DIFF
--- a/src/takedown.js
+++ b/src/takedown.js
@@ -23,60 +23,55 @@ async function initKnownUsers() {
 }
 
 async function processSpamRepliesFromDate(date) {
-  try {
-    let allSpamReplies = [];
+  let allSpamReplies = [];
 
-    // get all replies from date to now
-    for await (const replies of getRepliesInBatch(
-      date.toISOString(),
-      new Date().toISOString()
-    )) {
-      // filter out known users and duplicate texts
-      const filteredReplies = replies.filter((reply) => {
-        if (!knownUsers.has(reply.user.id) && !seenTexts.has(reply.text)) {
-          seenTexts.add(reply.text);
-          return true;
-        }
-        return false;
-      });
-
-      const list = await getSpamList(filteredReplies);
-
-      // add new spam users to knownUsers, we only need to create PR for them once
-      list.forEach((reply) => {
-        knownUsers.add(reply.user.id);
-      });
-
-      allSpamReplies = allSpamReplies.concat(list);
-    }
-
-    // deduplicate
-    const replyMap = new Map();
-    allSpamReplies.forEach((reply) => {
-      if (!replyMap.get(reply.user.id)) {
-        replyMap.set(reply.user.id, reply);
+  // get all replies from date to now
+  for await (const replies of getRepliesInBatch(
+    date.toISOString(),
+    new Date().toISOString()
+  )) {
+    // filter out known users and duplicate texts
+    const filteredReplies = replies.filter((reply) => {
+      if (!knownUsers.has(reply.user.id) && !seenTexts.has(reply.text)) {
+        seenTexts.add(reply.text);
+        return true;
       }
+      return false;
     });
-    const uniqueSpamReplies = Array.from(replyMap.values());
 
-    await Promise.all(
-      uniqueSpamReplies.map(async ({ id, user, text, createdAt }) => {
-        console.log('user: ', user.id, user.name, 'createdAt: ', createdAt);
-        const userReplyHistory = await getUserReplies(user.id);
-        await createPullRequest({
-          id,
-          userId: user.id,
-          userName: user.name,
-          spamContent: text,
-          createdAt,
-          userReplyHistory,
-        });
-      })
-    );
-  } catch (error) {
-    console.error('Error:', error.message);
-    return [];
+    const list = await getSpamList(filteredReplies);
+
+    // add new spam users to knownUsers, we only need to create PR for them once
+    list.forEach((reply) => {
+      knownUsers.add(reply.user.id);
+    });
+
+    allSpamReplies = allSpamReplies.concat(list);
   }
+
+  // deduplicate
+  const replyMap = new Map();
+  allSpamReplies.forEach((reply) => {
+    if (!replyMap.get(reply.user.id)) {
+      replyMap.set(reply.user.id, reply);
+    }
+  });
+  const uniqueSpamReplies = Array.from(replyMap.values());
+
+  await Promise.all(
+    uniqueSpamReplies.map(async ({ id, user, text, createdAt }) => {
+      console.log('user: ', user.id, user.name, 'createdAt: ', createdAt);
+      const userReplyHistory = await getUserReplies(user.id);
+      await createPullRequest({
+        id,
+        userId: user.id,
+        userName: user.name,
+        spamContent: text,
+        createdAt,
+        userReplyHistory,
+      });
+    })
+  );
 }
 
 async function main() {


### PR DESCRIPTION
This PR removes the try-catch block in the `processSpamRepliesFromDate` function, allowing errors to properly propagate up to the main catch handler. This ensures that GitHub workflows will fail appropriately when errors occur during spam reply processing, instead of silently continuing execution.

Before this change, the function would catch any errors, log them, and return an empty array, causing the workflow to continue as if nothing went wrong.