### PR TITLE
Create CODEOWNERS that auto adds moderators team as reviewer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @cofacts/moderators will be requested for review when
+# someone opens a pull request.
+
+*       @cofacts/moderators
+
+
+# left /src folder reviewer default empty
+
+/src/


### PR DESCRIPTION
Github App has some [problem](https://github.com/cli/cli/issues/6395) adding team as reviewer, so use [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) instead.

Note: team should be publicly visible, and have write access to the repository.

