### PR TITLE
fix: only run ci under src/test/.github folder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,21 @@ name: CI test
 on:
   # Triggers the workflow on push or pull request events
   push:
+    # Only run under listed folders
+    paths:
+      - '*'           # files in root
+      - 'src/**' 
+      - 'test/**'
+      - '.github/**'
     branches:
       - master
   pull_request:
+    # Only run under listed folders
+    paths:
+      - '*'           # files in root
+      - 'src/**' 
+      - 'test/**'
+      - '.github/**'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
Noticed that the previous takedown PR not only triggered coveralls comments but also inadvertently sent test data to langfuse, which could lead to data pollution.
To address this issue, modified the CI configuration to only run when changes occur in the `src`/`test`/`.github` folder.

ref: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-including-and-excluding-paths