### PR TITLE
feat: disable article detection since there are too many false positives

### DIFF
--- a/src/takedown.js
+++ b/src/takedown.js
@@ -148,7 +148,7 @@ async function main() {
     new Date().toISOString()
   );
   await processSpamRepliesFromDate(lastScannedAt);
-  await processSpamArticlesFromDate(lastScannedAt);
+  // await processSpamArticlesFromDate(lastScannedAt);
   await processSpamReplyRequestsFromDate(lastScannedAt);
 }
 


### PR DESCRIPTION
Since there are too many false positives, temporarily disable article detection.

We can discuss improving the detection mechanism or just stop here in the weekly meeting.