### PR TITLE
隱私資訊移除：2025/06/18 詐騙對話中的個人名字

### DIFF
--- a/2025/0618-privacy.md
+++ b/2025/0618-privacy.md
@@ -1,0 +1,45 @@
+# 2025/06/18 移除隱私資訊
+
+Cofacts 工作小組收到來信，要求移除以下含有當事人名字的訊息：
+
+- https://cofacts.tw/article/X13mXJcBfs35m9MiJ6pN
+- https://cofacts.tw/article/YV3mXJcBfs35m9MiK6pf
+- https://cofacts.tw/article/ZF3mXJcBfs35m9MiK6p7
+- https://cofacts.tw/article/Xl3mXJcBfs35m9MiJKq9
+- https://cofacts.tw/article/ZV3mXJcBfs35m9MiK6p-
+- https://cofacts.tw/article/Z13mXJcBfs35m9MiK6qR
+- https://cofacts.tw/article/aF3mXJcBfs35m9MiK6rq
+
+## 分析
+
+- 來信者表示「上傳幾則截圖要查詢是否爲詐騙。裡面有幾張截圖有我的名字」
+- Cofacts WG 檢視寄信者的 email，在其他公開之社群網站有發現該 Email 與相同的名字連結，判斷確實是本人來信。
+- 經檢視這些訊息，我們發現：
+
+### 包含來信者名字的訊息
+
+- https://cofacts.tw/article/X13mXJcBfs35m9MiJ6pN：與詐騙集團的 LINE 對話，其中有來信者使用的名字
+- https://cofacts.tw/article/ZF3mXJcBfs35m9MiK6p7：與詐騙集團的 LINE 對話，其中有來信者使用的名字
+- https://cofacts.tw/article/ZV3mXJcBfs35m9MiK6p-：詐騙集團所謂「核心權益公告」，來信者使用的名字被寫在「立約人」處
+- https://cofacts.tw/article/aF3mXJcBfs35m9MiK6rq：與詐騙集團的 LINE 對話，其中有來信者使用的名字、銀行帳號與來自詐團車手提供的「臨櫃收入」，應是詐團少量出金獲取信任
+
+### 不包含來信者名字的訊息
+
+- https://cofacts.tw/article/YV3mXJcBfs35m9MiK6pf：與詐騙集團的 LINE 對話，其中沒有來信者使用的名字
+- https://cofacts.tw/article/Xl3mXJcBfs35m9MiJKq9：與詐騙集團的 LINE 對話，其中沒有來信者使用的名字
+- https://cofacts.tw/article/Z13mXJcBfs35m9MiK6qR：假交易所截圖，其中沒有來信者使用的名字
+
+## 處置
+
+Cofacts WG 認為：
+
+1. 這些訊息揭露詐騙集團使用的話術與詐騙樣態，具備留存於 Cofacts 的公共利益
+2. 從這些截圖中遮除來信者名字，並不減損其公共利益
+
+因此，Cofacts WG 將以下訊息中，提及來信者名字的部分遮除：
+- https://cofacts.tw/article/X13mXJcBfs35m9MiJ6pN
+- https://cofacts.tw/article/ZF3mXJcBfs35m9MiK6p7
+- https://cofacts.tw/article/aF3mXJcBfs35m9MiK6rq
+- https://cofacts.tw/article/ZV3mXJcBfs35m9MiK6p-
+
+對於不包含來信者名字的訊息，則維持原樣。


### PR DESCRIPTION
## 說明

新增一則隱私資訊移除公告，處理詐騙集團LINE對話與詐騙文件中包含當事人名字的情況。

根據來信者要求，此PR將遮除以下文章中的個人名字：
- https://cofacts.tw/article/X13mXJcBfs35m9MiJ6pN
- https://cofacts.tw/article/ZF3mXJcBfs35m9MiK6p7
- https://cofacts.tw/article/ZV3mXJcBfs35m9MiK6p-
- https://cofacts.tw/article/aF3mXJcBfs35m9MiK6rq

同時保留這些文章揭露詐騙手法的公共利益內容。