### PR TITLE
refactor: remove article detection code to fix lint error

### DIFF
--- a/src/githubPR.js
+++ b/src/githubPR.js
@@ -39,19 +39,19 @@ function ellipsis(text, maxLength = 40) {
 
 const textMap = {
   reply: '查核回應',
-  article: '送出訊息',
+  article: '送出訊息', // eslint-disable-line no-unused-vars
   replyRequest: '回報補充',
 };
 
 const communityBuilderTypeMap = {
   reply: 0,
-  article: 2, // this type shows both replyRequest reason and article
+  article: 2, // this type shows both replyRequest reason and article // eslint-disable-line no-unused-vars
   replyRequest: 2,
 };
 
 const urlMap = {
   reply: 'reply',
-  article: 'article',
+  article: 'article', // eslint-disable-line no-unused-vars
   replyRequest: 'article', // Currently there is no direct link to replyRequest, so use article instead
 };
 

--- a/src/githubPR.js
+++ b/src/githubPR.js
@@ -39,19 +39,16 @@ function ellipsis(text, maxLength = 40) {
 
 const textMap = {
   reply: '查核回應',
-  article: '送出訊息', // eslint-disable-line no-unused-vars
   replyRequest: '回報補充',
 };
 
 const communityBuilderTypeMap = {
   reply: 0,
-  article: 2, // this type shows both replyRequest reason and article // eslint-disable-line no-unused-vars
   replyRequest: 2,
 };
 
 const urlMap = {
   reply: 'reply',
-  article: 'article', // eslint-disable-line no-unused-vars
   replyRequest: 'article', // Currently there is no direct link to replyRequest, so use article instead
 };
 
@@ -65,7 +62,7 @@ const urlMap = {
  * @param {string} params.spamContent - The content that was marked as spam
  * @param {string} params.createdAt - The creation date of the spam content
  * @param {Array} params.userHistory - Array of user's previous content
- * @param {string} params.contentType - Type of content ('reply', 'article', or 'replyRequest')
+ * @param {string} params.contentType - Type of content ('reply', 'replyRequest')
  * @returns {Object} The created pull request data
  */
 export async function createPullRequest({

--- a/src/takedown.js
+++ b/src/takedown.js
@@ -1,10 +1,8 @@
 import {
   getRepliesInBatch,
   getUserReplies,
-  getArticlesInBatch, // eslint-disable-line no-unused-vars
   getReplyRequestsInBatch,
   getUserReplyRequests,
-  getUserArticles, // eslint-disable-line no-unused-vars
 } from './util/graphql.js';
 import { getSpamList } from './getSpamList.js';
 import {
@@ -34,9 +32,9 @@ async function initKnownUsers() {
 /**
  * Generic function to process potential spam content from a specific date
  * @param {Date} date - Date to scan from
- * @param {Function} getBatchFn - Batch retrieval function to fetch content (getRepliesInBatch, getArticlesInBatch, getReplyRequestsInBatch)
+ * @param {Function} getBatchFn - Batch retrieval function to fetch content (getRepliesInBatch, getReplyRequestsInBatch)
  * @param {Function} getUserHistoryFn - function to get user history of specific type for creating PRs
- * @param {string} contentType - Type of content being processed ('reply', 'article', or 'replyRequest')
+ * @param {string} contentType - Type of content being processed ('reply', 'replyRequest')
  * @returns {Promise<Array>} - List of processed unique spam items
  */
 async function processSpamContentFromDate(
@@ -117,17 +115,6 @@ async function processSpamRepliesFromDate(date) {
   );
 }
 
-// eslint-disable-next-line no-unused-vars
-// Use the generic function for articles
-async function processSpamArticlesFromDate(date) {
-  return processSpamContentFromDate(
-    date,
-    getArticlesInBatch,
-    getUserArticles,
-    'article'
-  );
-}
-
 // Use the generic function for reply requests
 async function processSpamReplyRequestsFromDate(date) {
   return processSpamContentFromDate(
@@ -149,7 +136,6 @@ async function main() {
     new Date().toISOString()
   );
   await processSpamRepliesFromDate(lastScannedAt);
-  // await processSpamArticlesFromDate(lastScannedAt);
   await processSpamReplyRequestsFromDate(lastScannedAt);
 }
 

--- a/src/takedown.js
+++ b/src/takedown.js
@@ -1,10 +1,10 @@
 import {
   getRepliesInBatch,
   getUserReplies,
-  getArticlesInBatch,
+  getArticlesInBatch, // eslint-disable-line no-unused-vars
   getReplyRequestsInBatch,
   getUserReplyRequests,
-  getUserArticles,
+  getUserArticles, // eslint-disable-line no-unused-vars
 } from './util/graphql.js';
 import { getSpamList } from './getSpamList.js';
 import {
@@ -34,7 +34,7 @@ async function initKnownUsers() {
 /**
  * Generic function to process potential spam content from a specific date
  * @param {Date} date - Date to scan from
- * @param {Function} getBatchFn - Batch retrieval function to fetch content (getRepliesInBatch, getArticlesInBatch, etc.)
+ * @param {Function} getBatchFn - Batch retrieval function to fetch content (getRepliesInBatch, getArticlesInBatch, getReplyRequestsInBatch)
  * @param {Function} getUserHistoryFn - function to get user history of specific type for creating PRs
  * @param {string} contentType - Type of content being processed ('reply', 'article', or 'replyRequest')
  * @returns {Promise<Array>} - List of processed unique spam items
@@ -117,6 +117,7 @@ async function processSpamRepliesFromDate(date) {
   );
 }
 
+// eslint-disable-next-line no-unused-vars
 // Use the generic function for articles
 async function processSpamArticlesFromDate(date) {
   return processSpamContentFromDate(

--- a/src/util/graphql.js
+++ b/src/util/graphql.js
@@ -119,6 +119,7 @@ export async function getUserReplies(uid) {
   return ListReplies.edges.map(({ node }) => node);
 }
 
+// eslint-disable-next-line no-unused-vars
 // Async generator that gets a batch of articles with createdAt between `from` and `to`.
 // The generator encapsulates complex pagination logic so that the function using it can focus on
 // batch processing logic without worrying pagination.
@@ -304,6 +305,7 @@ export async function getUserReplyRequests(uid) {
   }));
 }
 
+// eslint-disable-next-line no-unused-vars
 /**
  * Get user's latest 10 articles
  */

--- a/src/util/graphql.js
+++ b/src/util/graphql.js
@@ -119,77 +119,6 @@ export async function getUserReplies(uid) {
   return ListReplies.edges.map(({ node }) => node);
 }
 
-// eslint-disable-next-line no-unused-vars
-// Async generator that gets a batch of articles with createdAt between `from` and `to`.
-// The generator encapsulates complex pagination logic so that the function using it can focus on
-// batch processing logic without worrying pagination.
-//
-export async function* getArticlesInBatch(from, to) {
-  // Get pageInfo outside the loop since it's expensive for rumors-api
-  const {
-    data: {
-      ListArticles: {
-        pageInfo: { lastCursor },
-      },
-    },
-  } = await graphql(
-    `
-      query ListArticlesStat($from: String!, $to: String!) {
-        ListArticles(
-          filter: { createdAt: { GT: $from, LT: $to } }
-          orderBy: { createdAt: DESC }
-        ) {
-          pageInfo {
-            lastCursor
-          }
-        }
-      }
-    `,
-    { from, to }
-  );
-
-  let after = null;
-  while (lastCursor !== after) {
-    // Actually loads `edges` and process.
-    const {
-      data: { ListArticles },
-    } = await graphql(
-      `
-        query ArticlesBetween($from: String!, $to: String!, $after: String) {
-          ListArticles(
-            filter: { createdAt: { GT: $from, LT: $to } }
-            after: $after
-            first: 25
-            orderBy: { createdAt: DESC }
-          ) {
-            edges {
-              node {
-                id
-                text
-                status
-                createdAt
-                user {
-                  id
-                  name
-                }
-              }
-              cursor
-            }
-          }
-        }
-      `,
-      { from, to, after }
-    );
-
-    yield ListArticles.edges
-      .filter(({ node }) => node.status !== 'BLOCKED')
-      .map(({ node }) => node);
-
-    // next graphql call should go after the last cursor of this page
-    after = ListArticles.edges[ListArticles.edges.length - 1].cursor;
-  }
-}
-
 /**
  * Async generator that gets a batch of reply requests with createdAt between `from` and `to`.
  * The generator encapsulates complex pagination logic so that the function using it can focus on
@@ -303,34 +232,4 @@ export async function getUserReplyRequests(uid) {
     text: node.reason, // Map reason to text to reuse getSpamList
     id: node.articleId, // Override id with articleId for createPullRequest
   }));
-}
-
-// eslint-disable-next-line no-unused-vars
-/**
- * Get user's latest 10 articles
- */
-export async function getUserArticles(uid) {
-  const {
-    data: { ListArticles },
-  } = await graphql(
-    `
-      query GetUserArticles($uid: String!) {
-        ListArticles(
-          filter: { userId: $uid }
-          first: 10
-          orderBy: { createdAt: DESC }
-        ) {
-          edges {
-            node {
-              id
-              text
-              createdAt
-            }
-          }
-        }
-      }
-    `,
-    { uid }
-  );
-  return ListArticles.edges.map(({ node }) => node);
 }


### PR DESCRIPTION
refactor: remove article detection code according to suggestion
- Remove all article-related imports, functions, and constants
- Clean up commented code blocks and eslint suppressions
- Keep codebase focused on reply and replyRequest detection only
- Article detection can be restored from git history if needed