### PR TITLE
fix: migrate to GitHub advanced search API to resolve deprecation warning

### DIFF
--- a/src/githubPR.js
+++ b/src/githubPR.js
@@ -220,6 +220,7 @@ export async function getAllPRs() {
         q: `repo:${owner}/${repo} is:pr in:title "Takedown spam user"`,
         per_page: 100, // get 100 pr per page
         page: page,
+        advanced_search: true, // Use advanced search to avoid deprecation warning
       });
 
       hasPRs = prs.length > 0;


### PR DESCRIPTION
Add 'advanced_search: true' parameter to search.issuesAndPullRequests API call to eliminate deprecation warning about the endpoint being overridden by advanced search on September 4, 2025.

The GitHub API will transition to advanced search as default after Sept 4, 2025, but the explicit parameter will remain supported for backward compatibility.

References:
- GitHub Blog: https://github.blog/changelog/2025-03-06-github-issues-projects-api-support-for-issues-advanced-search-and-more/
- GitHub REST API docs: https://docs.github.com/en/rest/search/search#search-issues-and-pull-requests

fixes #198