### PR TITLE
Loosen extract-api-info regex whitespace/fence-tag matching

### DIFF
--- a/.github/actions/extract-api-info/action.yml
+++ b/.github/actions/extract-api-info/action.yml
@@ -26,11 +26,11 @@ runs:
         script: |
           const prDescription = process.env.PR_DESCRIPTION || '';
 
-          // Extract API endpoint
-          const apiEndpointMatch = prDescription.match(/- API: `([^`]+)`/);
+          // Extract API endpoint (tolerate any amount of whitespace before the backtick)
+          const apiEndpointMatch = prDescription.match(/- API:\s*`([^`]+)`/);
 
-          // Extract API body
-          const apiBodyMatch = prDescription.match(/- Body:\s+```json\s+([\s\S]+?)\s+```/);
+          // Extract API body (the ```json language tag is optional)
+          const apiBodyMatch = prDescription.match(/- Body:\s+```(?:json)?\s+([\s\S]+?)\s+```/);
 
           // If no API information is found, set has-api-info to false
           if (!apiEndpointMatch || !apiBodyMatch) {


### PR DESCRIPTION
## 背景

在 review cofacts/devops #13（新增的 takedown skill 文件）時，實際執行了 `.github/actions/extract-api-info/action.yml` 裡的兩個 regex，發現對合理的格式變化會 silent no-op（`has-api-info=false`，CI 仍然綠燈，但封鎖指令根本沒有被解析出來）。

## 問題與修正

- `- API:` 的 regex（`/- API: `([^`]+)`/`）只容許剛好一個空格，PR 描述裡多打一個空格（例如 `- API:  `/moderation/blockUser`` ）就完全不 match。改成 `\s*`，容忍任意空白。
- `- Body:` 的 regex（`/- Body:\s+```json\s+([\s\S]+?)\s+```/`）寫死了 ` ```json ` 這個 fence tag，用純 ``` fence（GitHub markdown 本來就不強制要求 language tag）會 match 失敗。改成 ` ```(?:json)? `，容忍有無 `json` 標籤。

已用 Node.js 針對原始格式、多空格、無 json tag、兩個問題同時出現四種情況實際跑過，確認修正後都能正確解析、且不影響原本就正確的格式。

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVNcMAb5JkStcXuva83NaJ)_