### PR TITLE
Ignore workspace/ scratch dir used by /takedown skill investigations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ node_modules
 
 # Prevent google-github-actions/auth credentials being committed to git by accident
 gha-creds-*.json
+
+# Scratch space for /takedown skill investigations (see SKILL.md 步驟 5) — not version controlled
+workspace/


### PR DESCRIPTION
Closing — this was based on a wrong diagnosis. The `workspace/` scratch convention from the `/takedown` skill (`cofacts/devops` CLAUDE.md) belongs in the `cofacts/devops` working directory, which already `.gitignore`s `workspace/`. I had mistakenly created the scratch file inside `cofacts/takedowns` instead; the fix is to not do that, not to add an ignore rule here. Reverted the `.gitignore` change and moved the scratch note to the correct repo.